### PR TITLE
feat/updateNotice

### DIFF
--- a/energyplus/build.gradle
+++ b/energyplus/build.gradle
@@ -20,7 +20,7 @@ repositories {
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jdbc'
 	implementation 'org.springframework.boot:spring-boot-starter-jdbc'
-	/*implementation 'org.springframework.boot:spring-boot-starter-security'*/
+	/* implementation 'org.springframework.boot:spring-boot-starter-security' */
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.mybatis.spring.boot:mybatis-spring-boot-starter:3.0.4'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
@@ -30,7 +30,7 @@ dependencies {
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.mybatis.spring.boot:mybatis-spring-boot-starter-test:3.0.4'
-	/*testImplementation 'org.springframework.security:spring-security-test'*/
+	/* testImplementation 'org.springframework.security:spring-security-test' */
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 

--- a/energyplus/src/main/java/com/kh/ecolog/configuration/SecurityConfigure.java
+++ b/energyplus/src/main/java/com/kh/ecolog/configuration/SecurityConfigure.java
@@ -28,7 +28,8 @@ public class SecurityConfigure {
         http
             .csrf(AbstractHttpConfigurer::disable) 
             .authorizeHttpRequests(auth -> 
-                auth.requestMatchers("/members/**").permitAll() 
+                auth.requestMatchers("/members/**").permitAll()
+                	.requestMatchers("/notices/**").permitAll()
                     .anyRequest().authenticated() 
             )
             .formLogin(AbstractHttpConfigurer::disable)

--- a/energyplus/src/main/java/com/kh/ecolog/notice/model/dao/NoticeMapper.java
+++ b/energyplus/src/main/java/com/kh/ecolog/notice/model/dao/NoticeMapper.java
@@ -21,7 +21,6 @@ public interface NoticeMapper {
 	
 	void update(NoticeDTO notice);
 	
-	@Update("DELETE FROM TB_NOTICE WHERE NOTICE_ID = #{noticeId}")
     void deleteById(@Param("noticeId") Long noticeId);
 
 

--- a/energyplus/src/main/resources/mapper/notice-mapper.xml
+++ b/energyplus/src/main/resources/mapper/notice-mapper.xml
@@ -21,5 +21,24 @@
 							      #{userId}
 	  							  )
 	  </insert>
+	  
+	<update id="update" parameterType="com.kh.ecolog.notice.model.dto.NoticeDTO">
+	    UPDATE TB_NOTICE
+	    	SET
+		        NOTICE_TITLE = #{noticeTitle},
+		        NOTICE_CONTENT = #{noticeContent}
+	    WHERE
+	    	NOTICE_ID = #{noticeId}
+	</update>
+
+	<delete id="deleteById" parameterType="long">
+	    DELETE 
+	    	FROM
+	    		TB_NOTICE
+	    WHERE	
+	    	NOTICE_ID = #{noticeId}
+	</delete>
+
+	  
   
   </mapper>


### PR DESCRIPTION
[ 공지사항 수정 기능 추가]

작성자 : 김한슬
작성일자 : 2025-04-16 11:21

내용 : 공지사항 글 수정 기능을 추가 했습니다 .
 - NoticeController에 updateNotice 메서드 추가
- NoticeService 및 Mapper에 수정 로직 구현
- notice-mapper.xml에 UPDATE 쿼리 작성
- Postman으로 수정 기능 테스트 완료
- 
-  현재는 로그인/권한 체크 없이 전체 사용자 접근 가능 상태입니다. 추후 관리자 권한 체크 로직 추가 예정
확인부탁드립니다.