### PR TITLE
refactor/필드에서 기본값 제거하고 DB에 Default 설정

### DIFF
--- a/energyplus/src/main/java/com/kh/ecolog/member/model/dto/MemberDTO.java
+++ b/energyplus/src/main/java/com/kh/ecolog/member/model/dto/MemberDTO.java
@@ -18,7 +18,7 @@ import jakarta.validation.constraints.Size;
 public class MemberDTO {
 
 	private Long userId;
-	private Integer gradeId=1; // 기본 등급을 1(새싹)로 설정
+	private Integer gradeId;
 	
 	@Pattern(regexp="^[a-zA-Z0-9+-\\_.]+@[a-zA-Z0-9-]+\\.[a-zA-Z0-9-.]+$", message="유효한 이메일을 입력해쥬세요.")
 	@NotBlank(message="이메일은 반드시 입력바랍니다.")
@@ -41,6 +41,6 @@ public class MemberDTO {
 	private String userPhone;
 	
 	
-	private  String role = "ROLE_USER"; // 기본 역할로 설정
+	private  String role;
 	
 }


### PR DESCRIPTION
[MemberDTO 기본값 제거 및 DB Default 설정 적용]
작성자: 정승원
작성일: 2025년4월20일 18:18분
내용:
- MemberDTO에서 gradeId의 기본값(1) 설정 제거 및 role의 기본값(ROLE_USER) 제거하였습니다.
- DB에서 기본값을 관리하도록 수정하였습니다.
- 해당 커밋은 로그인 기능으로 잘못 커밋하였는데 login 브랜치와는 무관하여 별도의 브랜치(fix/MemberDTO-default)로 분리하여 커밋 정리 한 후 PR 진행했습니다.

확인 부탁드립니다.

