### PR TITLE
Fix/token

### DIFF
--- a/energyplus/build.gradle
+++ b/energyplus/build.gradle
@@ -27,6 +27,7 @@ dependencies {
 	implementation 'io.jsonwebtoken:jjwt-api:0.12.3'
 	implementation 'io.jsonwebtoken:jjwt-jackson:0.12.3'
 	implementation 'io.jsonwebtoken:jjwt-impl:0.12.3'
+	implementation 'org.springframework.boot:spring-boot-starter-mail:2.7.0'
 	
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.oracle.database.jdbc:ojdbc11'

--- a/energyplus/src/main/java/com/kh/ecolog/auth/controller/AuthController.java
+++ b/energyplus/src/main/java/com/kh/ecolog/auth/controller/AuthController.java
@@ -7,12 +7,14 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.kh.ecolog.auth.model.dto.LoginDTO;
 import com.kh.ecolog.auth.model.vo.CustomUserDetails;
 import com.kh.ecolog.auth.service.AuthService;
+import com.kh.ecolog.auth.util.JWTUtil;
 import com.kh.ecolog.token.model.service.TokenService;
 
 import jakarta.validation.Valid;
@@ -27,6 +29,7 @@ public class AuthController {
 
     private final AuthService authService;
     private final TokenService tokenService;
+    private final JWTUtil jwtUtil;
     
     @PostMapping("/login")
     public ResponseEntity<?> login(@Valid @RequestBody LoginDTO loginDTO){
@@ -59,14 +62,23 @@ public class AuthController {
         }
     }
     
+    
     @PostMapping("/logout")
-    public ResponseEntity<?> logout(@AuthenticationPrincipal CustomUserDetails userDetails){
-        if (userDetails == null) {
-            return ResponseEntity.badRequest().body(Map.of("message", "인증된 사용자가 아닙니다."));
+    public ResponseEntity<?> logout(@RequestHeader(value = "Authorization", required = false) String authorizationHeader) {
+        if (authorizationHeader == null || !authorizationHeader.startsWith("Bearer ")) {
+            return ResponseEntity.badRequest().body(Map.of("message", "유효한 인증 정보가 없습니다."));
         }
         
-        authService.logout(userDetails.getUserId());
-        
-        return ResponseEntity.ok(Map.of("message", "로그아웃 되었습니다."));
+        try {
+            String token = authorizationHeader.substring(7);
+            Long userId = jwtUtil.getUserIdFromToken(token);
+            
+            authService.logout(userId);
+            
+            return ResponseEntity.ok(Map.of("message", "로그아웃 되었습니다."));
+        } catch (Exception e) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
+                                .body(Map.of("error", "로그아웃 처리 중 오류가 발생했습니다."));
+        }
     }
 }

--- a/energyplus/src/main/java/com/kh/ecolog/auth/util/JWTUtil.java
+++ b/energyplus/src/main/java/com/kh/ecolog/auth/util/JWTUtil.java
@@ -37,11 +37,13 @@ public class JWTUtil {
 	/**
 	 * 액세스 토큰 생성 (30분 유효)
 	 * @param userEmail
+	 * @param userId
 	 * @return
 	 */
-	public String getAccessToken(String userEmail) {
+	public String getAccessToken(String userEmail, Long userId) {
 		return Jwts.builder()
-				   .subject(userEmail)
+				   .subject(userId.toString())
+				   .claim("userEmail", userEmail)
 				   .issuedAt(new Date())
 				   .expiration(new Date(System.currentTimeMillis() + 3600000L / 2))
 				   .signWith(key)
@@ -52,11 +54,13 @@ public class JWTUtil {
 	/**
 	 * 리프레시 토큰 생성 (30일 유효)
 	 * @param userEmail
+	 * @param userId
 	 * @return
 	 */
-	public String getRefreshToken(String userEmail) {
+	public String getRefreshToken(String userEmail, Long userId) {
 		return Jwts.builder()
-				   .subject(userEmail)
+				   .subject(userId.toString())
+				   .claim("userEmail", userEmail)
 				   .issuedAt(new Date())
 				   .expiration(new Date(System.currentTimeMillis() + 3600000L * 24 * 30))
 				   .signWith(key)		   
@@ -87,6 +91,26 @@ public class JWTUtil {
     public Long getExpirationTime(String token) {
         Claims claims = parseJwt(token);
         return claims.getExpiration().getTime();
+    }
+    
+    /**
+     * 토큰에서 사용자 ID 추출
+     * @param token 토큰
+     * @return 사용자 ID
+     */
+    public Long getUserIdFromToken(String token) {
+        Claims claims = parseJwt(token);
+        return Long.parseLong(claims.getSubject());
+    }
+    
+    /**
+     * 토큰에서 사용자 이메일 추출
+     * @param token 토큰
+     * @return 사용자 이메일
+     */
+    public String getUserEmailFromToken(String token) {
+        Claims claims = parseJwt(token);
+        return claims.get("userEmail", String.class);
     }
 	
 

--- a/energyplus/src/main/java/com/kh/ecolog/common/model/dao/service/EmailService.java
+++ b/energyplus/src/main/java/com/kh/ecolog/common/model/dao/service/EmailService.java
@@ -1,0 +1,20 @@
+package com.kh.ecolog.common.model.dao.service;
+
+public interface EmailService {
+	
+	/**
+	 * 이메일 발송 메서드
+	 * @param to 수신자 이메일
+	 * @param subject 이메일 제목
+	 * @param content 이메일 내용
+	 */
+	void sendEmail(String to, String subject, String content);
+	
+	/**
+	 * 회원가입 이메일 인증코드 발송
+	 * @param to
+	 * @param verificationCode 인증코드
+	 */
+	void sendSignUpVerificationEmail(String to, String verificationCode);
+
+}

--- a/energyplus/src/main/java/com/kh/ecolog/common/model/dao/service/VerificationService.java
+++ b/energyplus/src/main/java/com/kh/ecolog/common/model/dao/service/VerificationService.java
@@ -1,0 +1,33 @@
+package com.kh.ecolog.common.model.dao.service;
+
+public interface VerificationService {
+
+	/**
+	 * 인증 코드 생성 및 저장
+	 * @param email
+	 * @return
+	 */
+	String generateVerificationCode(String email);
+	
+	/**
+	 * 인증 코드 검증
+	 * @param email 
+	 * @param code
+	 * @return 검증결과(t->유효한 코드, f->유효하지 않은 코드)
+	 */
+	boolean verifyCode(String email, String code);
+	
+	/**
+	 * 이메일이 인증되었는지 확인
+	 * @param email 확인할 이메일
+	 * @return 인증여부(t->인증됨, f->인증되지않음)
+	 */
+	boolean isEmailVerified(String email);
+	
+	/**
+	 * 인증된 이메일 제거
+	 * @param email
+	 */
+	void removeVerifiedEmail(String email);
+	
+}

--- a/energyplus/src/main/resources/application.yml
+++ b/energyplus/src/main/resources/application.yml
@@ -14,6 +14,18 @@ spring:
   web:
     resources:
       static-locations: file:uploads/
+  mail:
+    host: smtp.gmail.com
+    port: 587
+    properties:
+      mail:
+        smtp:
+          auth: true
+          starttls:
+            enable: true
+          timeout: 5000
+          writetimeout: 5000
+          connectiontimeout: 5000
 
 server:
   port:  80


### PR DESCRIPTION
작성자 : 정승원
작성일 : 2025년04월24일 11시42분
### 수정 내용 : 
- ERD설계에 맞게 JWTUtil에서 토큰 생성 시 subject를 userId(시퀀스넘버)로 설정하도록 변경하였습니다.
- 이에따라 TokenServiceImpl, AuthController도 userId를 가져오도록 수정하였습니다.

### 변경이유 : 
DB에서 userId를 외래키로 사용하는 현재 구조와 일관성을 유지하기 위해 변경했습니다.

### postman 테스트여부
로그인, 토크갱신, 로그아웃 기능 테스트 완료하였습니다.
자세한 사용법은 PR #30을 확인부탁드립니다.

email 인증을 구현하다가 main으로 checkout 안하고 바로 token분기로 갔습니다. 이로인헤 이메일 작업도 pr에 올라간점 양해부탁드립니다.