### PR TITLE
feat/challengeDetail

### DIFF
--- a/energyplus/src/main/java/com/kh/ecolog/challenge/controller/ChallengeController.java
+++ b/energyplus/src/main/java/com/kh/ecolog/challenge/controller/ChallengeController.java
@@ -1,0 +1,52 @@
+package com.kh.ecolog.challenge.controller;
+
+import java.util.List;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.CrossOrigin;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.kh.ecolog.challenge.model.dto.ChallengeDTO;
+import com.kh.ecolog.challenge.model.service.ChallengeService;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@RestController
+@RequestMapping("/challenges")
+@CrossOrigin(origins = "http://localhost:5173")
+public class ChallengeController {
+
+    private final ChallengeService challengeService;
+
+    public ChallengeController(ChallengeService challengeService) {
+        this.challengeService = challengeService;
+    }
+
+    // 챌린지 목록 조회
+    @GetMapping
+    public ResponseEntity<List<ChallengeDTO>> getChallenges() {
+        List<ChallengeDTO> list = challengeService.getChallengeList();
+        return ResponseEntity.ok(list);
+    }
+
+    // 챌린지 상세 조회
+    @GetMapping("/{challengeSeq}")
+    public ResponseEntity<ChallengeDTO> getChallengeDetail(@PathVariable ("challengeSeq")Long challengeSeq) {
+        ChallengeDTO dto = challengeService.getChallengeDetail(challengeSeq);
+        return ResponseEntity.ok(dto);
+    }
+
+    // 챌린지 등록
+    @PostMapping
+    public ResponseEntity<Void> createChallenge(@RequestBody ChallengeDTO dto) {
+        challengeService.createChallenge(dto);
+        return ResponseEntity.ok().build();
+    }
+}

--- a/energyplus/src/main/java/com/kh/ecolog/challenge/model/dao/ChallengeMapper.java
+++ b/energyplus/src/main/java/com/kh/ecolog/challenge/model/dao/ChallengeMapper.java
@@ -1,0 +1,17 @@
+package com.kh.ecolog.challenge.model.dao;
+
+import java.util.List;
+
+import org.apache.ibatis.annotations.Mapper;
+
+import com.kh.ecolog.challenge.model.dto.ChallengeDTO;
+
+@Mapper
+public interface ChallengeMapper {
+
+	List<ChallengeDTO> selectChallengeList(); // 모든 챌린지 목록 조회 
+
+    ChallengeDTO selectChallengeDetail(Long challengeSeq); // 특정 챌린지 상세보기 
+
+    int insertChallenge(ChallengeDTO dto); // 챌린지 등록 
+}

--- a/energyplus/src/main/java/com/kh/ecolog/challenge/model/dto/ChallengeDTO.java
+++ b/energyplus/src/main/java/com/kh/ecolog/challenge/model/dto/ChallengeDTO.java
@@ -1,0 +1,27 @@
+package com.kh.ecolog.challenge.model.dto;
+
+import java.sql.Date;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@ToString
+public class ChallengeDTO {
+	
+	private Long challengeSeq;
+    private String challengeTitle;  
+    private String challengeContent;  
+    private String challengeStatus; 
+    private Long userId;
+    private Date enrollDate;
+    
+    private String userName;
+
+}

--- a/energyplus/src/main/java/com/kh/ecolog/challenge/model/service/ChallengeService.java
+++ b/energyplus/src/main/java/com/kh/ecolog/challenge/model/service/ChallengeService.java
@@ -1,0 +1,15 @@
+package com.kh.ecolog.challenge.model.service;
+
+import java.util.List;
+
+import com.kh.ecolog.challenge.model.dto.ChallengeDTO;
+
+public interface ChallengeService {
+
+	
+	List<ChallengeDTO> getChallengeList();
+
+    ChallengeDTO getChallengeDetail(Long challengeSeq);
+
+    int createChallenge(ChallengeDTO dto);
+}

--- a/energyplus/src/main/java/com/kh/ecolog/challenge/model/service/ChallengeServiceImpl.java
+++ b/energyplus/src/main/java/com/kh/ecolog/challenge/model/service/ChallengeServiceImpl.java
@@ -1,0 +1,37 @@
+package com.kh.ecolog.challenge.model.service;
+
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+
+import com.kh.ecolog.challenge.model.dao.ChallengeMapper;
+import com.kh.ecolog.challenge.model.dto.ChallengeDTO;
+
+@Service
+public class ChallengeServiceImpl implements ChallengeService{
+
+	private final ChallengeMapper challengeMapper;
+	
+	public ChallengeServiceImpl(ChallengeMapper challengeMapper) {
+		this.challengeMapper = challengeMapper;
+	}
+	
+	
+	@Override
+	public List<ChallengeDTO> getChallengeList(){
+		return challengeMapper.selectChallengeList();
+	}
+	
+	@Override
+	public ChallengeDTO getChallengeDetail(Long challengeSeq) {
+		return challengeMapper.selectChallengeDetail(challengeSeq);
+	}
+	
+	@Override
+	public int createChallenge(ChallengeDTO dto) {
+		return challengeMapper.insertChallenge(dto);
+	}
+	
+	
+	
+}

--- a/energyplus/src/main/java/com/kh/ecolog/challengeParticipation/model/dto/ChallengeParticipationDTO.java
+++ b/energyplus/src/main/java/com/kh/ecolog/challengeParticipation/model/dto/ChallengeParticipationDTO.java
@@ -1,0 +1,27 @@
+package com.kh.ecolog.challengeParticipation.model.dto;
+
+import java.sql.Date;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@ToString
+public class ChallengeParticipationDTO {
+
+	 private Long participationSeq;  
+	 private Long challengeSeq; 
+	 private Integer mileageRewarded;
+	 private Date rewardedDate;     
+	 private Date participationDate;  
+	 private String participationImg;
+	 private String participationStatus;
+	 private String rejectReason; 
+}

--- a/energyplus/src/main/java/com/kh/ecolog/configuration/SecurityConfigure.java
+++ b/energyplus/src/main/java/com/kh/ecolog/configuration/SecurityConfigure.java
@@ -59,7 +59,7 @@ public class SecurityConfigure {
                 .requestMatchers(
                     "/members/**", "/markets/**", "/notices/**", "/apis/**",
                     "/uploads/**", "/resources/**", "/css/**", "/js/**", "/images/**",
-                    "/qnas/**", "/replys/**"
+                    "/qnas/**", "/replys/**", "/challenges/**"
                 ).permitAll()
                 .anyRequest().authenticated()
 

--- a/energyplus/src/main/java/com/kh/ecolog/qna_reply/controller/QnaReplyController.java
+++ b/energyplus/src/main/java/com/kh/ecolog/qna_reply/controller/QnaReplyController.java
@@ -36,9 +36,8 @@ public class QnaReplyController {
 	
 	@GetMapping
 	public ResponseEntity<List<QnaReplyDTO>> selectReplyList(
-			@RequestParam(name="qnaId") Long qnaId){
+			@RequestParam(name="qnaId")String qnaId){
 		//log.info("{}", qnaId);
-		QnaReplyDTO reply = qnaReplyService.selectReplyList(qnaId);
 		return ResponseEntity.ok(qnaReplyService.selectReplyList(Long.parseLong(qnaId)));
 	}
 	

--- a/energyplus/src/main/resources/application.yml
+++ b/energyplus/src/main/resources/application.yml
@@ -1,4 +1,8 @@
 spring:
+  servlet:
+    multipart:
+      max-file-size: 100MB
+      max-request-size: 100MB
   application:
     name:  energyplus
 
@@ -18,14 +22,10 @@ spring:
 server:
   port:  80
 
-servlet:
-  multipart:
-    max-file-size: 100MB
-    max-request-size: 100MB
 
 mybatis:
   configuration:
     log-impl: org.apache.ibatis.logging.stdout.StdOutImpl
     jdbc-type-for-null: VARCHAR
   mapper-locations: classpath:mapper/**/*.xml
-  type-aliases-package: com.kh.ecolog.qna.model.vo, com.kh.ecolog.qna.model.dto, com.kh.ecolog.notice.model.dto, com.kh.ecolog.token.vo
+  type-aliases-package: com.kh.ecolog.qna.model.vo, com.kh.ecolog.qna.model.dto, com.kh.ecolog.notice.model.dto, com.kh.ecolog.token.vo, com.kh.ecolog.challenge.model.dto

--- a/energyplus/src/main/resources/mapper/challenge-mapper.xml
+++ b/energyplus/src/main/resources/mapper/challenge-mapper.xml
@@ -1,0 +1,62 @@
+<!DOCTYPE mapper
+  PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+  "https://mybatis.org/dtd/mybatis-3-mapper.dtd">
+  
+	<mapper namespace="com.kh.ecolog.challenge.model.dao.ChallengeMapper">
+	
+	  <!-- 챌린지 목록 -->
+	  <select id="selectChallengeList" resultType="com.kh.ecolog.challenge.model.dto.ChallengeDTO">
+	    SELECT 
+	      c.CHALLENGE_SEQ AS challengeSeq,
+	      c.CHALLENGE_TITLE AS challengeTitle,
+	      c.CHALLENGE_CONTENT AS challengeContent,
+	      c.CHALLENGE_STATUS AS challengeStatus,
+	      c.USER_ID AS userId,
+	      c.ENROLL_DATE AS enrollDate,
+	      u.USER_NAME AS userName
+	    FROM 
+	      TB_CHALLENGE c
+	     JOIN
+	     	TB_USER u ON c.USER_ID = u.USER_ID
+	    ORDER BY 
+	      c.CHALLENGE_SEQ DESC
+	  </select>
+	
+	  <!-- 챌린지 상세 -->
+	  <select id="selectChallengeDetail" parameterType="long"
+	          resultType="com.kh.ecolog.challenge.model.dto.ChallengeDTO">
+	    SELECT 
+	      c.CHALLENGE_SEQ AS challengeSeq,
+	      c.CHALLENGE_TITLE AS challengeTitle,
+	      c.CHALLENGE_CONTENT AS challengeContent,
+	      c.CHALLENGE_STATUS AS challengeStatus,
+	      c.USER_ID AS userId,
+	      c.ENROLL_DATE AS enrollDate,
+	      u.USER_NAME AS userName
+	    FROM 
+	      TB_CHALLENGE c
+	    JOIN
+	      TB_USER u ON c.USER_ID = u.USER_ID
+	    WHERE 
+	      c.CHALLENGE_SEQ = #{challengeSeq}
+	  </select>
+	
+	  <!-- 챌린지 등록 -->
+	  <insert id="insertChallenge" parameterType="com.kh.ecolog.challenge.model.dto.ChallengeDTO">
+	    INSERT INTO TB_CHALLENGE (
+	      CHALLENGE_SEQ,
+	      CHALLENGE_TITLE,
+	      CHALLENGE_CONTENT,
+	      CHALLENGE_STATUS,
+	      USER_ID
+	    )
+	    VALUES (
+	      SEQ_CHALLENGE.NEXTVAL,
+	      #{challengeTitle},
+	      #{challengeContent},
+	      #{challengeStatus},
+	      #{userId}
+	    )
+	  </insert>
+	
+	</mapper>


### PR DESCRIPTION
작성자 : 김한슬
일자 : 2025.04.24
내용 : 
-챌린지 목록 조회 API 추가 (GET /challenges)
- 챌린지 상세 조회 API 추가 (GET /challenges/{challengeSeq})
- ChallengeDTO에 userName, enrollDate 필드 추가
- MyBatis 매퍼(challenge-mapper.xml)에 TB_USER 조인 및 컬럼 매핑
- SecurityConfigure에 GET /challenges/** 접근 허용 설정