### PR TITLE
fix/JWTFilter에userID 추가

### DIFF
--- a/energyplus/src/main/java/com/kh/ecolog/auth/controller/test/TestController.java
+++ b/energyplus/src/main/java/com/kh/ecolog/auth/controller/test/TestController.java
@@ -1,0 +1,31 @@
+package com.kh.ecolog.auth.controller.test;
+
+import java.util.Map;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.kh.ecolog.auth.model.vo.CustomUserDetails;
+
+@RestController
+@RequestMapping("test")
+public class TestController {
+    
+	@GetMapping("/auth-check")
+	public ResponseEntity<?> checkAuth(@AuthenticationPrincipal CustomUserDetails userDetails) {
+	    if (userDetails == null) {
+	        return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
+	                           .body(Map.of("error", "인증 정보가 없습니다. 로그인이 필요합니다."));
+	    }
+	    
+	    return ResponseEntity.ok(Map.of(
+	        "message", "인증 성공!",
+	        "user", userDetails.getUsername(),
+	        "userId", userDetails.getUserId()
+	    ));
+	}
+}

--- a/energyplus/src/main/java/com/kh/ecolog/configuration/SecurityConfigure.java
+++ b/energyplus/src/main/java/com/kh/ecolog/configuration/SecurityConfigure.java
@@ -58,7 +58,7 @@ public class SecurityConfigure {
                 .requestMatchers(
                     "/members/**", "/markets/**", "/notices/**", "/apis/**",
                     "/uploads/**", "/resources/**", "/css/**", "/js/**", "/images/**",
-                    "/qnas/**", "/replys/**"
+                    "/qnas/**", "/replys/**", "/test/**"
                 ).permitAll()
                 .anyRequest().authenticated()
 

--- a/energyplus/src/main/java/com/kh/ecolog/configuration/filter/JwtFilter.java
+++ b/energyplus/src/main/java/com/kh/ecolog/configuration/filter/JwtFilter.java
@@ -56,7 +56,9 @@ public class JwtFilter extends OncePerRequestFilter {
         
         try {
             Claims claims = jwtUtil.parseJwt(token);
-            String userEmail = claims.getSubject();
+
+            Long userId = jwtUtil.getUserIdFromToken(token);
+            String userEmail = jwtUtil.getUserEmailFromToken(token);
             
             if (SecurityContextHolder.getContext().getAuthentication() == null) {
                 UserDetails userDetails = usrDetailsService.loadUserByUsername(userEmail);
@@ -68,19 +70,19 @@ public class JwtFilter extends OncePerRequestFilter {
                 authentication.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
                 SecurityContextHolder.getContext().setAuthentication(authentication);
                 
-                log.debug("사용자 인증 성공: {}", userEmail);
+                log.debug("사용자 인증 성공: {}, 사용자 ID: {}", userEmail, userId);
             }
             
         } catch (ExpiredJwtException e) {
             log.warn("만료된 JWT 토큰: {}", e.getMessage());
             response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
             response.getWriter().write("토큰이 만료되었습니다. 다시 로그인해주세요.");
-            return;
-        } catch (Exception e) {
+            return;            
+        } catch(Exception e) {
             log.error("JWT 처리 중 오류 발생: {}", e.getMessage());
             response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
             response.getWriter().write("유효하지 않은 토큰입니다.");
-            return;
+            return;      	
         }
         
         // 다음 필터로 진행


### PR DESCRIPTION
작성자 : 정승원
작성일 : 2025년04월24일 15시09분
### 변경 내용
- JWTFilter에서도 토큰애서 userId를 가져오도록 수정하였습니다.
- TestController를 사용하여 userId가 나오는지 확인하였습니다.

### postman으로 확인하는 방법
1. GET localhost:80/test/auth-check
2. Authorization 탭에서 Bearer Token 타입 선택
3. 로그인 시 받은 accessToken 입력

이 방법으로 테스트해보면 인증된 사용자의 ID가 응답에 포함되어 뽑히는게 확인됩니다.